### PR TITLE
Update quarantine-admin-manage-messages-files.md

### DIFF
--- a/microsoft-365/security/office-365-security/quarantine-admin-manage-messages-files.md
+++ b/microsoft-365/security/office-365-security/quarantine-admin-manage-messages-files.md
@@ -52,7 +52,7 @@ Watch this short video to learn how to manage quarantined messages as an admin.
 
 - You need to be assigned permissions before you can do the procedures in this article. You have the following options:
   - [Exchange Online RBAC](/exchange/permissions-exo/permissions-exo):
-    - _Take action on quarantined messages for all users_: Membership in the **Organization Management**, **Security Administrator**, or **Quarantine Administrator** role groups.
+    - _Take action on quarantined messages for all users_: Membership in the **Organization Management**, or **Security Administrator**, or **Hygiene Management** role groups.
     - _Submit messages from quarantine to Microsoft_:  Membership in the **Security Administrator** role group.
     - _Read-only access to quarantined messages for all users_: Membership in the **Global Reader**, **Security Reader**, or **View-Only Organization Management** role groups.
   - [Email & collaboration RBAC in the Microsoft 365 Defender portal](mdo-portal-permissions.md): Membership in the **Quarantine Administrator** role group. To do quarantine procedures in Exchange Online PowerShell, you also need membership in the **Hygiene Management** role group in Exchange Online RBAC.


### PR DESCRIPTION
There is no 'Quarantine Administrator' role I can find documented for Exchange Online RBAC. That role only is documented as part of the Defender 365 so-called Unified RBAC.

The appropriate role in Exchange Online RBAC appears to be "Hygiene Management".  Based on what I've read, both that role AND the "Quarantine Administrator" role are needed.

<!--
Microsoft Entra rebrand: Please do not submit pull requests containing branding updates from Azure Active Directory, Azure AD, AAD, etc, to their respective Microsoft Entra equivalents at this time. 

Microsoft Entra rebranding is being coordinated across the Learn platform and will be applied to this repo automatically when we receive confirmation that product UIs have been updated. If you have questions regarding the rebrand project, contact dstrome.

This text can be deleted.
-->
